### PR TITLE
Specs fixes and new expect syntax

### DIFF
--- a/spec/plugin/parsing_spec.rb
+++ b/spec/plugin/parsing_spec.rb
@@ -18,7 +18,7 @@ describe "Parsing" do
     vim.edit 'grep_results'
     vim.command 'call writable_search#Parse()'
 
-    vim.buffer_contents.should eq normalize_string_indent(<<-EOF)
+    expect(vim.buffer_contents).to eq normalize_string_indent(<<-EOF)
       autoload/writable_search/proxy.vim:26-28
        " to adjust next proxies.
        function! writable_search#proxy#UpdateSource(new_lines, adjustment) dict
@@ -47,7 +47,7 @@ describe "Parsing" do
 
     vim.edit 'grep_results'
     vim.command 'call writable_search#Parse()'
-    vim.buffer_contents.should eq normalize_string_indent(<<-EOF)
+    expect(vim.buffer_contents).to eq normalize_string_indent(<<-EOF)
       autoload/writable_search/proxy.vim:26-28
        " to adjust next proxies.
        function! writable_search#proxy#UpdateSource(new_lines, adjustment) dict

--- a/spec/plugin/renaming_files_spec.rb
+++ b/spec/plugin/renaming_files_spec.rb
@@ -2,33 +2,22 @@ require 'spec_helper'
 
 describe "Renaming files" do
   it "can rename files" do
-    write_file 'one.txt', 'One'
+    write_file 'one.txt', 'One Two'
     write_file 'two.txt', 'Two'
 
-    vim.set_buffer_contents normalize_string_indent(<<-EOF)
-      one.txt:1:One
-      --
-      two.txt:1:Two
-    EOF
-    vim.command 'call writable_search#Parse()'
+    vim.command 'WritableSearch Two'
 
     vim.command '%s/two.txt/three.txt/g'
     vim.write
 
-    IO.read('one.txt').strip.should eq 'One'
-    File.exists?('two.txt').should be_false
+    IO.read('one.txt').strip.should eq 'One Two'
+    File.exists?('two.txt').should eq false
     IO.read('three.txt').strip.should eq 'Two'
   end
 
   it "can handle two renames of a single file" do
     write_file 'one.txt', "One\nOne"
-
-    vim.set_buffer_contents normalize_string_indent(<<-EOF)
-      one.txt:1:One
-      --
-      one.txt:2:One
-    EOF
-    vim.command 'call writable_search#Parse()'
+    vim.command 'WritableSearch One'
 
     vim.command '%s/one.txt/two.txt/g'
     vim.command '%s/One/Two/g'
@@ -36,26 +25,21 @@ describe "Renaming files" do
     vim.write
 
     IO.read('two.txt').strip.should eq "Two\nTwo"
-    File.exists?('one.txt').should be_false
+    File.exists?('one.txt').should eq false
   end
 
   it "can move files to new directories" do
     FileUtils.mkdir('dir')
-    write_file 'dir/one.txt', 'One'
+    write_file 'dir/one.txt', 'One Two'
     write_file 'dir/two.txt', 'Two'
 
-    vim.set_buffer_contents normalize_string_indent(<<-EOF)
-      dir/one.txt:1:One
-      --
-      dir/two.txt:1:Two
-    EOF
-    vim.command 'call writable_search#Parse()'
+    vim.command 'WritableSearch Two'
 
     vim.command '%s?dir/two.txt?other_dir/three.txt?g'
     vim.write
 
-    IO.read('dir/one.txt').strip.should eq 'One'
-    File.exists?('dir/two.txt').should be_false
+    IO.read('dir/one.txt').strip.should eq 'One Two'
+    File.exists?('dir/two.txt').should eq false
     IO.read('other_dir/three.txt').strip.should eq 'Two'
   end
 end

--- a/spec/plugin/renaming_files_spec.rb
+++ b/spec/plugin/renaming_files_spec.rb
@@ -10,9 +10,9 @@ describe "Renaming files" do
     vim.command '%s/two.txt/three.txt/g'
     vim.write
 
-    IO.read('one.txt').strip.should eq 'One Two'
-    File.exists?('two.txt').should eq false
-    IO.read('three.txt').strip.should eq 'Two'
+    expect(IO.read('one.txt').strip).to eq 'One Two'
+    expect(File.exists?('two.txt')).to eq false
+    expect(IO.read('three.txt').strip).to eq 'Two'
   end
 
   it "can handle two renames of a single file" do
@@ -24,8 +24,8 @@ describe "Renaming files" do
 
     vim.write
 
-    IO.read('two.txt').strip.should eq "Two\nTwo"
-    File.exists?('one.txt').should eq false
+    expect(IO.read('two.txt').strip).to eq "Two\nTwo"
+    expect(File.exists?('one.txt')).to eq false
   end
 
   it "can move files to new directories" do
@@ -38,8 +38,8 @@ describe "Renaming files" do
     vim.command '%s?dir/two.txt?other_dir/three.txt?g'
     vim.write
 
-    IO.read('dir/one.txt').strip.should eq 'One Two'
-    File.exists?('dir/two.txt').should eq false
-    IO.read('other_dir/three.txt').strip.should eq 'Two'
+    expect(IO.read('dir/one.txt').strip).to eq 'One Two'
+    expect(File.exists?('dir/two.txt')).to eq false
+    expect(IO.read('other_dir/three.txt').strip).to eq 'Two'
   end
 end

--- a/spec/plugin/searching_spec.rb
+++ b/spec/plugin/searching_spec.rb
@@ -11,7 +11,7 @@ describe "Searching" do
 
     vim.command 'WritableSearch Two'
 
-    vim.buffer_contents.should eq normalize_string_indent(<<-EOF)
+    expect(vim.buffer_contents).to eq normalize_string_indent(<<-EOF)
       one.txt:1-1
        One Two Three
       two.txt:1-1
@@ -31,14 +31,14 @@ describe "Searching" do
     vim.command 'WritableSearch One'
 
     vim.command 'Rerun -C1'
-    vim.buffer_contents.should eq normalize_string_indent(<<-EOF)
+    expect(vim.buffer_contents).to eq normalize_string_indent(<<-EOF)
       one.txt:1-2
        One
        Two
     EOF
 
     vim.command 'Rerun -C5'
-    vim.buffer_contents.should eq normalize_string_indent(<<-EOF)
+    expect(vim.buffer_contents).to eq normalize_string_indent(<<-EOF)
       one.txt:1-5
        One
        Two
@@ -54,7 +54,7 @@ describe "Searching" do
 
     vim.command 'WritableSearch One'
 
-    vim.buffer_contents.should eq normalize_string_indent(<<-EOF)
+    expect(vim.buffer_contents).to eq normalize_string_indent(<<-EOF)
       one.txt:1-1
        One
     EOF

--- a/spec/plugin/searching_spec.rb
+++ b/spec/plugin/searching_spec.rb
@@ -12,10 +12,10 @@ describe "Searching" do
     vim.command 'WritableSearch Two'
 
     vim.buffer_contents.should eq normalize_string_indent(<<-EOF)
-      two.txt:1-1
-       Two Three Four
       one.txt:1-1
        One Two Three
+      two.txt:1-1
+       Two Three Four
     EOF
   end
 

--- a/spec/plugin/updating_from_source_spec.rb
+++ b/spec/plugin/updating_from_source_spec.rb
@@ -13,6 +13,6 @@ describe "Updating from source" do
 
     vim.write
 
-    vim.buffer_contents.should include 'One Foo Three'
+    expect(vim.buffer_contents).to include 'One Foo Three'
   end
 end

--- a/spec/plugin/updating_source_spec.rb
+++ b/spec/plugin/updating_source_spec.rb
@@ -15,8 +15,8 @@ describe "Updating source" do
     vim.command '%s/Two/Foo/g'
     vim.write
 
-    IO.read('one.txt').strip.should eq 'One Foo Three'
-    IO.read('two.txt').strip.should eq 'Foo Three Four'
+    expect(IO.read('one.txt').strip).to eq 'One Foo Three'
+    expect(IO.read('two.txt').strip).to eq 'Foo Three Four'
   end
 
   it "updates two instances of the same file correctly" do
@@ -38,6 +38,6 @@ describe "Updating source" do
 
     vim.write
 
-    IO.read('one.txt').strip.should eq "One\nTwo\nThree\nFive"
+    expect(IO.read('one.txt').strip).to eq "One\nTwo\nThree\nFive"
   end
 end


### PR DESCRIPTION
I was getting rename/search spec failures locally, so I've tried to fix them (not sure what the reason was).

Can you look through commits to see if fixes are valid.

Also, changed specs to RSpec `expect` syntax.